### PR TITLE
Fix Tailwind CSS not loading

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,6 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
-  }
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }


### PR DESCRIPTION
## Summary
- fix PostCSS plugins so Tailwind styles compile

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684067217f388323acf1fa05a83cedab